### PR TITLE
Region index for cheaper, smarter job pathfinding

### DIFF
--- a/components/gamemapsingleton.go
+++ b/components/gamemapsingleton.go
@@ -12,13 +12,26 @@ type GameMapSingleton struct {
 	Ups            []Position
 	Downs          []Position
 	Stockpiles     map[Position]enums.ItemTypeEnum
+
+	// RegionIDs maps every walkable tile to a connected-component ID so that
+	// reachability checks can be answered with a map lookup instead of an
+	// A* search. Two tiles share an ID iff a worker can walk between them
+	// (with stair pairs bridging adjacent Z-levels). Unwalkable / unknown
+	// tiles have no entry, which RegionAt reports as 0.
+	RegionIDs map[Position]int
+	// RegionDirty signals that the cached RegionIDs are out of date and
+	// must be rebuilt before the next consumer reads them. Set by
+	// MarkRegionDirty whenever a tile's walkability changes.
+	RegionDirty bool
 }
 
 func NewGameMapSingleton() GameMapSingleton {
 	gm := GameMapSingleton{
-		Grids:      make(map[int]*paths.Grid),
-		Tiles:      make(map[Position]*Tile),
-		Stockpiles: make(map[Position]enums.ItemTypeEnum),
+		Grids:       make(map[int]*paths.Grid),
+		Tiles:       make(map[Position]*Tile),
+		Stockpiles:  make(map[Position]enums.ItemTypeEnum),
+		RegionIDs:   make(map[Position]int),
+		RegionDirty: true,
 	}
 
 	return gm

--- a/helpers/gamemap.go
+++ b/helpers/gamemap.go
@@ -93,7 +93,10 @@ func RemoveResourceFromTile(w engine.World, pos components.Position, rt enums.Re
 	}
 
 	cell := gms.Grids[pos.Z].Get(pos.X, pos.Y)
-	cell.Walkable = walkable
+	if cell.Walkable != walkable {
+		cell.Walkable = walkable
+		MarkRegionDirty(w, gms)
+	}
 
 	RenderTile(w, pos)
 }
@@ -105,13 +108,23 @@ func AddBuildingToTile(w engine.World, pos components.Position, tt enums.TileTyp
 	tile.Buildings = append(tile.Buildings, components.NewBuilding(tt))
 
 	cell := gms.Grids[pos.Z].Get(pos.X, pos.Y)
+	walkChanged := cell.Walkable != walkable
 	cell.Walkable = walkable
 
+	addedStair := false
 	switch tt {
 	case enums.TileTypeStairDown:
 		gms.Downs = append(gms.Downs, pos)
+		addedStair = true
 	case enums.TileTypeStairUp:
 		gms.Ups = append(gms.Ups, pos)
+		addedStair = true
+	}
+
+	// A new stair changes inter-Z connectivity even if its own cell was
+	// already walkable, so always invalidate when one is placed.
+	if walkChanged || addedStair {
+		MarkRegionDirty(w, gms)
 	}
 
 	RenderTile(w, pos)
@@ -129,7 +142,10 @@ func MineTile(w engine.World, pos components.Position) {
 	tile.TileTypeEnum = enums.TileTypeRockFloor
 
 	cell := gms.Grids[pos.Z].Get(pos.X, pos.Y)
-	cell.Walkable = true
+	if !cell.Walkable {
+		cell.Walkable = true
+		MarkRegionDirty(w, gms)
+	}
 
 	RenderTile(w, pos)
 }

--- a/helpers/jobs.go
+++ b/helpers/jobs.go
@@ -1,15 +1,37 @@
 package helpers
 
 import (
+	"sort"
+
 	"github.com/sedyh/mizu/pkg/engine"
 	"github.com/tomknightdev/dwarven-fortresses/components"
 	"github.com/tomknightdev/dwarven-fortresses/entities"
 	"github.com/tomknightdev/dwarven-fortresses/enums"
 )
 
+// GetJob looks for an unclaimed, unblocked job that the worker at pos can
+// reach, and returns the job entity together with a path to it.
+//
+// The search uses the cached region index to discard jobs that are
+// definitely unreachable without running A* on them, then sorts the
+// surviving candidates by distance and only A*-searches them in
+// closest-first order. The dwarf therefore picks up the nearest reachable
+// job rather than whichever one happens to come first in the ECS view.
 func GetJob(w engine.World, pos components.Position) (engine.Entity, []components.Path) {
+	gms := GetGameMapSingleton(w)
+	EnsureRegions(gms)
+
+	workerRegion := RegionAt(gms, pos)
+
+	type candidate struct {
+		ent  engine.Entity
+		job  *components.Job
+		dist int
+	}
+
 	jobs := w.View(components.Job{}).Filter()
 	var job *components.Job
+	var candidates []candidate
 
 	for _, j := range jobs {
 		j.Get(&job)
@@ -18,27 +40,99 @@ func GetJob(w engine.World, pos components.Position) (engine.Entity, []component
 			continue
 		}
 
-		if Matches(pos, job.Tasks[0].Position) {
+		target := job.Tasks[0].Position
+		if Matches(pos, target) {
+			// Standing on it — return the job with no movement required.
 			return j, nil
 		}
 
-		var paths []components.Path
+		// Region filter: skip jobs the worker provably can't reach. This
+		// turns "run A* on every job to find out it's hopeless" into a
+		// cheap map lookup. workerRegion == 0 means the worker itself is
+		// on an unwalkable tile (shouldn't happen) — fall back to the
+		// pre-region behaviour by accepting every candidate.
+		if workerRegion != 0 {
+			taskType := job.Tasks[0].TaskTypeEnum
+			if taskType == enums.TaskTypePickUp || taskType == enums.TaskTypeDrop {
+				// Worker walks onto the target tile, so the target itself
+				// must be in the same region.
+				if RegionAt(gms, target) != workerRegion {
+					continue
+				}
+			} else {
+				// Worker only needs to reach a neighbour (chop, mine,
+				// build, add-to-stockpile).
+				reachable := false
+				for _, r := range AdjacentRegions(gms, target) {
+					if r == workerRegion {
+						reachable = true
+						break
+					}
+				}
+				if !reachable {
+					continue
+				}
+			}
+		}
 
-		if job.Tasks[0].TaskTypeEnum == enums.TaskTypePickUp || job.Tasks[0].TaskTypeEnum == enums.TaskTypeDrop {
-			paths = GetPath(w, pos, job.Tasks[0].Position)
+		candidates = append(candidates, candidate{
+			ent:  j,
+			job:  job,
+			dist: travelHeuristic(pos, target),
+		})
+	}
+
+	sort.Slice(candidates, func(i, k int) bool {
+		return candidates[i].dist < candidates[k].dist
+	})
+
+	for _, c := range candidates {
+		target := c.job.Tasks[0].Position
+		var paths []components.Path
+		if c.job.Tasks[0].TaskTypeEnum == enums.TaskTypePickUp || c.job.Tasks[0].TaskTypeEnum == enums.TaskTypeDrop {
+			paths = GetPath(w, pos, target)
 		} else {
-			paths = GetPathToAdjacent(w, pos, job.Tasks[0].Position)
+			paths = GetPathToAdjacent(w, pos, target)
 		}
 
 		if len(paths) == 0 {
-			job.Tasks[0].Blocked = true
+			// Region said reachable but A* failed (rare — happens if the
+			// region index was stale for this tick, or if there's no
+			// stair path despite same-region membership). Mark the task
+			// blocked; it will un-block automatically on the next
+			// walkability change via MarkRegionDirty.
+			c.job.Tasks[0].Blocked = true
 			continue
 		}
 
-		return j, paths
+		return c.ent, paths
 	}
 
 	return nil, nil
+}
+
+// travelHeuristic estimates how far the worker has to walk to reach a job.
+// It's a Chebyshev distance on XY (matches the 8-direction grid) plus a
+// per-Z penalty, since changing levels requires routing through a stair.
+// Only used to order candidates — not a cost the pathfinder consumes.
+func travelHeuristic(a, b components.Position) int {
+	dx := a.X - b.X
+	if dx < 0 {
+		dx = -dx
+	}
+	dy := a.Y - b.Y
+	if dy < 0 {
+		dy = -dy
+	}
+	dz := a.Z - b.Z
+	if dz < 0 {
+		dz = -dz
+	}
+	cheb := dx
+	if dy > cheb {
+		cheb = dy
+	}
+	return cheb + 6*dz
 }
 
 func CreateJobs(w engine.World, jobType enums.TaskTypeEnum, jobCost int, positions ...components.Position) {

--- a/helpers/region.go
+++ b/helpers/region.go
@@ -1,0 +1,172 @@
+package helpers
+
+import (
+	"github.com/sedyh/mizu/pkg/engine"
+	"github.com/tomknightdev/dwarven-fortresses/assets"
+	"github.com/tomknightdev/dwarven-fortresses/components"
+)
+
+// MarkRegionDirty signals that walkability has changed and the cached
+// region index must be rebuilt before the next consumer reads it. It also
+// clears the Blocked flag on every open task so that previously
+// unreachable jobs get re-evaluated against the new map state.
+//
+// Call this from any code path that flips a cell's Walkable bit.
+func MarkRegionDirty(w engine.World, gms *components.GameMapSingleton) {
+	gms.RegionDirty = true
+
+	jobs := w.View(components.Job{}).Filter()
+	var job *components.Job
+	for _, j := range jobs {
+		j.Get(&job)
+		for i := range job.Tasks {
+			job.Tasks[i].Blocked = false
+		}
+	}
+}
+
+// EnsureRegions rebuilds the region index if it is dirty. Cheap to call
+// every tick — it is a no-op when clean.
+func EnsureRegions(gms *components.GameMapSingleton) {
+	if !gms.RegionDirty && gms.RegionIDs != nil {
+		return
+	}
+	rebuildRegions(gms)
+	gms.RegionDirty = false
+}
+
+// RegionAt returns the region ID of the given position, or 0 if the tile
+// is unwalkable or out of bounds. Region IDs start at 1.
+func RegionAt(gms *components.GameMapSingleton, pos components.Position) int {
+	if gms.RegionIDs == nil {
+		return 0
+	}
+	return gms.RegionIDs[pos]
+}
+
+// SameRegion reports whether two positions are part of the same connected
+// region. An unwalkable tile (region 0) is never equal to anything,
+// including another unwalkable tile.
+func SameRegion(gms *components.GameMapSingleton, a, b components.Position) bool {
+	ra := RegionAt(gms, a)
+	if ra == 0 {
+		return false
+	}
+	return ra == RegionAt(gms, b)
+}
+
+// AdjacentRegions returns the distinct region IDs of the 8 walkable
+// neighbours of pos. Used when a job's target tile is itself unwalkable
+// (a tree, a rock wall) and the worker only has to reach one of its
+// neighbours.
+func AdjacentRegions(gms *components.GameMapSingleton, pos components.Position) []int {
+	var ids []int
+	seen := make(map[int]struct{})
+	for dx := -1; dx <= 1; dx++ {
+		for dy := -1; dy <= 1; dy++ {
+			if dx == 0 && dy == 0 {
+				continue
+			}
+			n := components.NewPosition(pos.X+dx, pos.Y+dy, pos.Z)
+			if n.X < 0 || n.Y < 0 || n.X >= assets.WorldWidth || n.Y >= assets.WorldHeight {
+				continue
+			}
+			id := RegionAt(gms, n)
+			if id == 0 {
+				continue
+			}
+			if _, ok := seen[id]; ok {
+				continue
+			}
+			seen[id] = struct{}{}
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
+
+// rebuildRegions recomputes the region index from scratch by flood-filling
+// every walkable tile across all Z-levels. Stair pairs (a Down at z and an
+// Up at z-1 sharing X/Y) act as bidirectional bridges between levels, so
+// floors connected only by stairs end up in the same region.
+func rebuildRegions(gms *components.GameMapSingleton) {
+	regions := make(map[components.Position]int, len(gms.Tiles))
+
+	// Build the cross-Z adjacency from stair pairs.
+	crossZ := make(map[components.Position][]components.Position)
+	addLink := func(a, b components.Position) {
+		crossZ[a] = append(crossZ[a], b)
+		crossZ[b] = append(crossZ[b], a)
+	}
+	for _, d := range gms.Downs {
+		addLink(d, components.NewPosition(d.X, d.Y, d.Z-1))
+	}
+	for _, u := range gms.Ups {
+		addLink(u, components.NewPosition(u.X, u.Y, u.Z+1))
+	}
+
+	walkable := func(p components.Position) bool {
+		g, ok := gms.Grids[p.Z]
+		if !ok {
+			return false
+		}
+		if p.X < 0 || p.Y < 0 || p.X >= assets.WorldWidth || p.Y >= assets.WorldHeight {
+			return false
+		}
+		return g.Get(p.X, p.Y).Walkable
+	}
+
+	nextID := 1
+	stack := make([]components.Position, 0, 64)
+
+	for p := range gms.Tiles {
+		if _, done := regions[p]; done {
+			continue
+		}
+		if !walkable(p) {
+			continue
+		}
+
+		id := nextID
+		nextID++
+		regions[p] = id
+		stack = append(stack[:0], p)
+
+		for len(stack) > 0 {
+			cur := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+
+			// 8-neighbour flood on the same Z.
+			for dx := -1; dx <= 1; dx++ {
+				for dy := -1; dy <= 1; dy++ {
+					if dx == 0 && dy == 0 {
+						continue
+					}
+					n := components.NewPosition(cur.X+dx, cur.Y+dy, cur.Z)
+					if !walkable(n) {
+						continue
+					}
+					if _, done := regions[n]; done {
+						continue
+					}
+					regions[n] = id
+					stack = append(stack, n)
+				}
+			}
+
+			// Stair links bridge to the floor above/below.
+			for _, n := range crossZ[cur] {
+				if !walkable(n) {
+					continue
+				}
+				if _, done := regions[n]; done {
+					continue
+				}
+				regions[n] = id
+				stack = append(stack, n)
+			}
+		}
+	}
+
+	gms.RegionIDs = regions
+}


### PR DESCRIPTION
Idle dwarves used to run a full A* search against every open job until one happened to be reachable, returning whichever came first in the ECS view. With N idle workers and M jobs that's up to N*M searches per tick, and dwarves often picked far jobs over nearby ones.

This change adds a connected-components map to GameMapSingleton: every walkable tile gets a region ID, with stair pairs bridging adjacent Z-levels. The index is rebuilt lazily — MarkRegionDirty flips a flag whenever a tile's walkability changes, and the next consumer (GetJob) calls EnsureRegions to refresh.

GetJob now:
  1. Filters jobs by region (cheap map lookup) so unreachable ones never hit A* at all.
  2. Sorts the survivors by Chebyshev distance + Z penalty.
  3. Runs A* on the closest reachable candidate first.

A side effect of MarkRegionDirty is that all task Blocked flags are cleared on every walkability change, so jobs that were previously unreachable un-block themselves as soon as the map reconnects (e.g. once a stair gets dug down to them) instead of staying permanently stuck.

Hooks live in the three central tile-mutation helpers (RemoveResourceFromTile, AddBuildingToTile, MineTile).